### PR TITLE
Add __clang__ with __gnuc__ since there are implementations of clang,…

### DIFF
--- a/test/boost/core/current_function.hpp
+++ b/test/boost/core/current_function.hpp
@@ -32,7 +32,7 @@ inline void current_function_helper()
 
 # define BOOST_CURRENT_FUNCTION "(unknown)"
 
-#elif defined(__GNUC__) || (defined(__MWERKS__) && (__MWERKS__ >= 0x3000)) || (defined(__ICC) && (__ICC >= 600)) || defined(__ghs__)
+#elif defined(__GNUC__) || (defined(__MWERKS__) && (__MWERKS__ >= 0x3000)) || (defined(__ICC) && (__ICC >= 600)) || defined(__ghs__) || defined(__clang__)
 
 # define BOOST_CURRENT_FUNCTION __PRETTY_FUNCTION__
 


### PR DESCRIPTION
… ie. Embarcadero and Intel C++ on Windows, which do not use gcc.