### PR TITLE
Conditionally unpack an error_id from a thrown system_error

### DIFF
--- a/include/boost/leaf/handle_errors.hpp
+++ b/include/boost/leaf/handle_errors.hpp
@@ -33,13 +33,14 @@ namespace boost { namespace leaf {
         static error_id unpack_error_id( std::exception const * ex ) noexcept
         {
             if( std::system_error const * se = dynamic_cast<std::system_error const *>(ex) )
-                return error_id(se->code());
-            else if( std::error_code const * ec = dynamic_cast<std::error_code const *>(ex) )
-                return error_id(*ec);
-            else if( error_id const * err_id = dynamic_cast<error_id const *>(ex) )
+                if( is_error_id(se->code()) )
+                    return error_id(se->code());
+            if( std::error_code const * ec = dynamic_cast<std::error_code const *>(ex) )
+                if( is_error_id(*ec) )
+                    return error_id(*ec);
+            if( error_id const * err_id = dynamic_cast<error_id const *>(ex) )
                 return *err_id;
-            else
-                return current_error();
+            return current_error();
         }
 
         std::exception * const ex_;


### PR DESCRIPTION
Previously, if a `std::system_error` was caught and passed to
`unpack_error_id`, then the `ex.code()` would be unconditionally
converted to an `error_id`, even if the code did not correspond
to an actual `error_id` value. This effectively prevents reliable
use of `std::system_error` as an exception type.

This tweaks to only consider the `system_error` to be an `error_id`
if the `code()` of that error matches `is_error_id()`.