### PR TITLE
Fix namespace error.hpp

### DIFF
--- a/include/boost/leaf/error.hpp
+++ b/include/boost/leaf/error.hpp
@@ -50,7 +50,7 @@
     else\
         return BOOST_LEAF_TMP.error()
 
-#define BOOST_LEAF_NEW_ERROR boost::leaf::leaf_detail::inject_loc{__FILE__,__LINE__,__FUNCTION__}+::boost::leaf::new_error
+#define BOOST_LEAF_NEW_ERROR ::boost::leaf::leaf_detail::inject_loc{__FILE__,__LINE__,__FUNCTION__}+::boost::leaf::new_error
 
 namespace boost { namespace leaf {
 

--- a/include/boost/leaf/error.hpp
+++ b/include/boost/leaf/error.hpp
@@ -50,7 +50,7 @@
     else\
         return BOOST_LEAF_TMP.error()
 
-#define BOOST_LEAF_NEW_ERROR ::leaf::leaf_detail::inject_loc{__FILE__,__LINE__,__FUNCTION__}+::boost::leaf::new_error
+#define BOOST_LEAF_NEW_ERROR boost::leaf::leaf_detail::inject_loc{__FILE__,__LINE__,__FUNCTION__}+::boost::leaf::new_error
 
 namespace boost { namespace leaf {
 


### PR DESCRIPTION
To use BOOST_LEAF_NEW_ERROR macro, it should be declared as below in user's source or header file.
Without them, the macro is not working.

```c++
//  leaf issue, BOOST_LEAF_NEW_ERROR macro, ::leaf::
namespace leaf = boost::leaf;
```

For using LEAF without it, "::boost::" would be added in below namespace.

As-is:
```c++
#define BOOST_LEAF_NEW_ERROR ::leaf::leaf_detail::inject_loc{__FILE__,__LINE__,__FUNCTION__}+::boost::leaf::new_error
```

To-be:
```c++
#define BOOST_LEAF_NEW_ERROR ::boost::leaf::leaf_detail::inject_loc{__FILE__,__LINE__,__FUNCTION__}+::boost::leaf::new_error
```
