### PR TITLE
Update metadata

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -9,7 +9,7 @@
     ],
     "description": "A lightweight error-handling library for C++11.",
     "category": [
-        "Error-handling"
+        "Miscellaneous"
     ],
     "cxxstd": "11"
 }


### PR DESCRIPTION

Set metadata to match the corresponding category on boost.org website.   

Even when it comes to the "Miscellaneous" category, this is how it is often configured, refer to "core", "logic", other repos.

 
