### PR TITLE
Fix: Return rvalue-ref to stored_ in rref-qualified deref-operators

### DIFF
--- a/include/boost/leaf/result.hpp
+++ b/include/boost/leaf/result.hpp
@@ -381,12 +381,12 @@ public:
 
     value_rv_cref operator*() const &&
     {
-        return value();
+        return std::move(*this).value();
     }
 
     value_rv_ref operator*() &&
     {
-        return value();
+        return std::move(*this).value();
     }
 
     value_type_const * operator->() const


### PR DESCRIPTION
`result::value()` correctly returns `std::move(stored_)`, but `operator*` simply returns `value()`, which will always call the lref-qualified `value()`, and incorrectly attempt to bind the returned (lvalue reference) to an rvalue reference.

This change calls `move(*this)` for an rvalue call to `value()`