### PR TITLE
Support handlers catching abstract exception types.

### DIFF
--- a/include/boost/leaf/context.hpp
+++ b/include/boost/leaf/context.hpp
@@ -80,22 +80,10 @@ namespace leaf_detail
         using exc_type = typename std::decay<Exc>::type;
 
         template <class Tup>
-        BOOST_LEAF_CONSTEXPR static exc_type * check(Tup const &, error_info const & ei) noexcept
-        {
-#ifndef BOOST_LEAF_NO_EXCEPTIONS
-            return dynamic_cast<exc_type*>(ei.exception());
-#else
-            return nullptr;
-#endif
-        }
+        BOOST_LEAF_CONSTEXPR static exc_type * check( Tup const &, error_info const & ) noexcept;
 
         template <class Tup>
-        BOOST_LEAF_CONSTEXPR static exc_type & get(Tup const &, error_info const & ei) noexcept
-        {
-#ifndef BOOST_LEAF_NO_EXCEPTIONS
-            return dynamic_cast<exc_type&>(*ei.exception());
-#endif
-        }
+        BOOST_LEAF_CONSTEXPR static exc_type & get( Tup const &, error_info const & ) noexcept;
     };
 
     template <class Pred>

--- a/include/boost/leaf/handle_errors.hpp
+++ b/include/boost/leaf/handle_errors.hpp
@@ -465,8 +465,8 @@ namespace leaf_detail
     template <class A>
     template <class Tup>
     BOOST_LEAF_CONSTEXPR inline
-    typename handler_argument_traits_defaults<A, false>::error_type const *
-    handler_argument_traits_defaults<A, false>::
+    typename handler_argument_traits_defaults<A, false, false>::error_type const *
+    handler_argument_traits_defaults<A, false, false>::
     check( Tup const & tup, error_info const & ei ) noexcept
     {
         return peek<typename std::decay<A>::type>(tup, ei);
@@ -475,8 +475,8 @@ namespace leaf_detail
     template <class A>
     template <class Tup>
     BOOST_LEAF_CONSTEXPR inline
-    typename handler_argument_traits_defaults<A, false>::error_type *
-    handler_argument_traits_defaults<A, false>::
+    typename handler_argument_traits_defaults<A, false, false>::error_type *
+    handler_argument_traits_defaults<A, false, false>::
     check( Tup & tup, error_info const & ei ) noexcept
     {
         return peek<typename std::decay<A>::type>(tup, ei);

--- a/include/boost/leaf/handle_errors.hpp
+++ b/include/boost/leaf/handle_errors.hpp
@@ -482,6 +482,32 @@ namespace leaf_detail
         return peek<typename std::decay<A>::type>(tup, ei);
     }
 
+    template <class Exc>
+    template <class Tup>
+    BOOST_LEAF_CONSTEXPR inline
+    typename handler_argument_traits_defaults<Exc, false, true>::exc_type *
+    handler_argument_traits_defaults<Exc, false, true>::
+    check( Tup const &, error_info const & ei ) noexcept
+    {
+#ifndef BOOST_LEAF_NO_EXCEPTIONS
+        return dynamic_cast<exc_type*>(ei.exception());
+#else
+        return nullptr;
+#endif
+    }
+
+    template <class Exc>
+    template <class Tup>
+    BOOST_LEAF_CONSTEXPR inline
+    typename handler_argument_traits_defaults<Exc, false, true>::exc_type &
+    handler_argument_traits_defaults<Exc, false, true>::
+    get( Tup const &, error_info const & ei ) noexcept
+    {
+#ifndef BOOST_LEAF_NO_EXCEPTIONS
+        return dynamic_cast<exc_type&>(*ei.exception());
+#endif
+    }
+
     template <class Tup>
     BOOST_LEAF_CONSTEXPR inline
     std::exception const *


### PR DESCRIPTION
- Because it is impossible to create an instance of an abstract type, we
  do not need a slot for that type. Overload the error_type to be
  `void`.
- For `check()` and `get()`, ignore the error value tuple and just
  inspect the in-flight exception only.