### PR TITLE
Remove const from e_source_location data members

### DIFF
--- a/doc/leaf.adoc
+++ b/doc/leaf.adoc
@@ -2069,7 +2069,7 @@ leaf::try_handle_some(
   },
 
   []( leaf::match<std::error_code, my_error_condition::c1> m )
-  { 
+  {
     assert(m.matched == my_error_condition::c1);
     ....
   } );
@@ -4103,9 +4103,9 @@ namespace boost { namespace leaf {
 
   struct e_source_location
   {
-    char const * const file;
-    int const line;
-    char const * const function;
+    char const * file;
+    int line;
+    char const * function;
 
     friend std::ostream & operator<<( std::ostream & os, e_source_location const & x );
   };

--- a/include/boost/leaf/error.hpp
+++ b/include/boost/leaf/error.hpp
@@ -233,9 +233,9 @@ namespace boost { namespace leaf {
 
 struct e_source_location
 {
-    char const * const file;
-    int const line;
-    char const * const function;
+    char const * file;
+    int line;
+    char const * function;
 
     template <class CharT, class Traits>
     friend std::basic_ostream<CharT, Traits> & operator<<( std::basic_ostream<CharT, Traits> & os, e_source_location const & x )


### PR DESCRIPTION
Doing so will allow copying of e_source_location objects. This is
especially handy if a developer wants to make a fixed sized array
of e_source_location objects and update the elements for purposes of
creating a stack trace.