### PR TITLE
Fixup FreeRTOS support in LEAF

### DIFF
--- a/include/boost/leaf/detail/config.hpp
+++ b/include/boost/leaf/detail/config.hpp
@@ -213,12 +213,13 @@
 
 ////////////////////////////////////////
 
-#if defined(BOOST_LEAF_NO_THREADS)
+#if defined(BOOST_LEAF_TLS_FREERTOS)
+#   define BOOST_LEAF_NO_THREADS
+#   include <boost/leaf/detail/tls_freertos.hpp>
+#elif defined(BOOST_LEAF_NO_THREADS)
 #   include <boost/leaf/detail/tls_globals.hpp>
-#elif defined(BOOST_LEAF_TLS_FREERTOS)
-#	include <boost/leaf/detail/tls_freertos.hpp>
 #else
-#	include <boost/leaf/detail/tls_cpp11.hpp>
+#	  include <boost/leaf/detail/tls_cpp11.hpp>
 #endif
 
 #if defined(_MSC_VER) && !defined(BOOST_LEAF_ENABLE_WARNINGS) ///

--- a/include/boost/leaf/detail/tls_freertos.hpp
+++ b/include/boost/leaf/detail/tls_freertos.hpp
@@ -25,7 +25,7 @@
 #endif ///
 
 #include <task.h> // From FreeRTOS
-#define BOOST_LEAF_TLS_INDEX_TYPE BaseType_t;
+#define BOOST_LEAF_TLS_INDEX_TYPE BaseType_t
 #include <boost/leaf/detail/tls_index.hpp>
 #undef BOOST_LEAF_TLS_INDEX_TYPE
 #include <atomic>
@@ -43,7 +43,7 @@ namespace tls
     template <class T>
     T * ptr_read() noexcept
     {
-        return reinterpret_cast<T *>(vTaskGetThreadLocalStoragePointer(0, index<T>::idx));
+        return reinterpret_cast<T *>(pvTaskGetThreadLocalStoragePointer(0, index<T>::idx));
     }
 
     template <class T>

--- a/include/boost/leaf/detail/tls_index.hpp
+++ b/include/boost/leaf/detail/tls_index.hpp
@@ -32,11 +32,8 @@ namespace boost { namespace leaf {
         template <class T>
         struct BOOST_LEAF_SYMBOL_VISIBLE index
         {
-             static BOOST_LEAF_TLS_INDEX_TYPE const idx = index_counter<>::c++;
+            inline static BOOST_LEAF_TLS_INDEX_TYPE const idx = index_counter<>::c++;
         };
-
-        template <class T>
-        static BOOST_LEAF_TLS_INDEX_TYPE const index<T>::idx;
     }
 
 } }


### PR DESCRIPTION
- In config.hpp defining BOOST_LEAF_TLS_FREERTOS should also define
  BOOST_LEAF_NO_THREADS in order to remove the usage of std::thread in
  the rest of the project.
- Remove ";" from BOOST_LEAF_TLS_INDEX_TYPE macro
- Use correct FreeRTOS API for setting and reading TLS array elements