### PR TITLE
Fix gcc syntax warnings enabled with -Wall and -Wpedantic

### DIFF
--- a/include/boost/leaf/context.hpp
+++ b/include/boost/leaf/context.hpp
@@ -72,7 +72,7 @@ namespace leaf_detail
         {
             auto e = base::check(tup, ei);
             return e && Pred::evaluate(*e);
-        };
+        }
 
         template <class Tup>
         BOOST_LEAF_CONSTEXPR static Pred get( Tup const & tup, error_info const & ei ) noexcept
@@ -91,7 +91,7 @@ namespace leaf_detail
         BOOST_LEAF_CONSTEXPR static bool check( Tup &, error_info const & ) noexcept
         {
             return true;
-        };
+        }
     };
 
     template <class E>

--- a/include/boost/leaf/error.hpp
+++ b/include/boost/leaf/error.hpp
@@ -308,20 +308,24 @@ namespace leaf_detail
     BOOST_LEAF_CONSTEXPR inline void load_unexpected_count( int err_id ) noexcept
     {
         if( slot<e_unexpected_count> * sl = tls::read_ptr<slot<e_unexpected_count>>() )
+        {
             if( e_unexpected_count * unx = sl->has_value(err_id) )
                 ++unx->count;
             else
                 sl->put(err_id, e_unexpected_count(&type<E>));
+        }
     }
 
     template <class E>
     BOOST_LEAF_CONSTEXPR inline void load_unexpected_info( int err_id, E && e ) noexcept
     {
         if( slot<e_unexpected_info> * sl = tls::read_ptr<slot<e_unexpected_info>>() )
+        {
             if( e_unexpected_info * unx = sl->has_value(err_id) )
                 unx->add(std::forward<E>(e));
             else
                 sl->put(err_id, e_unexpected_info()).add(std::forward<E>(e));
+        }
     }
 
     template <class E>
@@ -380,10 +384,12 @@ namespace leaf_detail
         static_assert(!std::is_pointer<E>::value, "Error objects of pointer types are not allowed");
         BOOST_LEAF_ASSERT((err_id&3)==1);
         if( auto sl = tls::read_ptr<slot<E>>() )
+        {
             if( auto v = sl->has_value(err_id) )
                 (void) std::forward<F>(f)(*v);
             else
                 (void) std::forward<F>(f)(sl->put(err_id,E()));
+        }
         return 0;
     }
 }

--- a/include/boost/leaf/handle_errors.hpp
+++ b/include/boost/leaf/handle_errors.hpp
@@ -460,12 +460,14 @@ namespace leaf_detail
     peek( SlotsTuple const & tup, error_info const & ei ) noexcept
     {
         if( error_id err = ei.error() )
+        {
             if( E const * e = peek_tuple<E>::peek(tup, err) )
                 return e;
 #ifndef BOOST_LEAF_NO_EXCEPTIONS
             else
                 return peek_exception<E const>::peek(ei);
 #endif
+        }
         return nullptr;
     }
 
@@ -475,12 +477,14 @@ namespace leaf_detail
     peek( SlotsTuple & tup, error_info const & ei ) noexcept
     {
         if( error_id err = ei.error() )
+        {
             if( E * e = peek_tuple<E>::peek(tup, err) )
                 return e;
 #ifndef BOOST_LEAF_NO_EXCEPTIONS
             else
                 return peek_exception<E>::peek(ei);
 #endif
+        }
         return nullptr;
     }
 }

--- a/include/boost/leaf/on_error.hpp
+++ b/include/boost/leaf/on_error.hpp
@@ -180,10 +180,12 @@ namespace leaf_detail
         {
             BOOST_LEAF_ASSERT((err_id&3)==1);
             if( s_ )
+            {
                 if( E * e = s_->has_value(err_id) )
                     (void) f_(*e);
                 else
                     (void) f_(s_->put(err_id, E()));
+            }
         }
     };
 

--- a/include/boost/leaf/pred.hpp
+++ b/include/boost/leaf/pred.hpp
@@ -216,7 +216,7 @@ struct is_predicate<match_member<P, V1, V...>>: std::true_type
 template <class P>
 struct if_not
 {
-    using error_type = typename P::error_type;;
+    using error_type = typename P::error_type;
     decltype(std::declval<P>().matched) matched;
 
     template <class E>


### PR DESCRIPTION
Some minor syntax issues (missing braces and extra semicolons) cause GCC to complain with -Wpedantic enabled. This PR allows compilation with -Wpedantic.

If you can give guidance on how to enable these flags in CI, I'll add them there as well.