### PR TITLE
Upgrade MacOS drone tests

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -44,7 +44,7 @@ local linux_pipeline(name, image, environment, packages = "", sources = [], arch
     ]
 };
 
-local macos_pipeline(name, environment, xcode_version = "12.2", osx_version = "catalina", arch = "amd64") =
+local macos_pipeline(name, environment, xcode_version = "14.1", osx_version = "monterey", arch = "arm64") =
 {
     name: name,
     kind: "pipeline",
@@ -213,13 +213,13 @@ local windows_pipeline(name, image, environment, arch = "amd64") =
     ),
 
     macos_pipeline(
-        "MacOS 10.15 Xcode 12.2 UBSAN",
-        { TOOLSET: 'clang', COMPILER: 'clang++', CXXSTD: '11,14,1z' } + ubsan,
+        "MacOS 12.5.1 Xcode 14.1 UBSAN",
+        { TOOLSET: 'clang', COMPILER: 'clang++', CXXSTD: '14,17,20' } + ubsan,
     ),
 
     macos_pipeline(
-        "MacOS 10.15 Xcode 12.2 ASAN",
-        { TOOLSET: 'clang', COMPILER: 'clang++', CXXSTD: '11,14,1z' } + asan,
+        "MacOS 12.5.1 Xcode 14.1 ASAN",
+        { TOOLSET: 'clang', COMPILER: 'clang++', CXXSTD: '14,17,20' } + asan,
     ),
 
     windows_pipeline(

--- a/.drone/drone.sh
+++ b/.drone/drone.sh
@@ -7,6 +7,7 @@
 set -ex
 
 DRONE_BUILD_DIR=$(pwd)
+export PATH=~/.local/bin:/usr/local/bin:$PATH
 
 BOOST_BRANCH=develop
 if [ "$DRONE_BRANCH" = "master" ]; then BOOST_BRANCH=master; fi


### PR DESCRIPTION
Current MacOS drone tests are taking 3 hours.  Newer drone agents should improve the situation since they are faster and less busy.  Let's try switching to those machines. I have not pre-tested this pull request, so check if drone succeeds before merging.